### PR TITLE
🔒 Add explicit permissions to GitHub Actions workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,6 +9,10 @@ on:
       - main
       - develop
 
+# 明示的なパーミッション設定を追加
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Set contents permission to read for improved security
- Update continuous integration workflow configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - GitHub Actions のワークフローで、リポジトリ内容へのアクセス権が「読み取り」に明示的に設定されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->